### PR TITLE
Fix: Make Locator Bar GameRule check use player's current level.

### DIFF
--- a/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
+++ b/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
@@ -1,7 +1,12 @@
+/*
+ * Copyright (c) 2025 senseiwells
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
 package net.casual.arcade.dimensions.mixins.level;
 
 import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.casual.arcade.dimensions.level.CustomLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.waypoints.ServerWaypointManager;
 import net.minecraft.world.level.GameRules;
@@ -12,8 +17,11 @@ import org.spongepowered.asm.mixin.injection.At;
 public class ServerWaypointManagerMixin {
 
     @ModifyReceiver(method = "isLocatorBarEnabledFor", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"))
-    private static GameRules fixVanillaLocatorBarGameRuleCheck(GameRules instance, GameRules.Key<GameRules.BooleanValue> key, @Local(argsOnly = true) ServerPlayer player) {
-        return player.level().getGameRules();
+    private static GameRules fixVanillaLocatorBarGameRuleCheck(GameRules original, GameRules.Key<GameRules.BooleanValue> key, @Local(argsOnly = true) ServerPlayer player) {
+        if (player.level() instanceof CustomLevel) {
+            return player.level().getGameRules();
+        }
+        return original;
     }
 
 }

--- a/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
+++ b/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
@@ -1,0 +1,19 @@
+package net.casual.arcade.dimensions.mixins.level;
+
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.waypoints.ServerWaypointManager;
+import net.minecraft.world.level.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ServerWaypointManager.class)
+public class ServerWaypointManagerMixin {
+
+    @ModifyReceiver(method = "isLocatorBarEnabledFor", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"))
+    private static GameRules fixVanillaLocatorBarGameRuleCheck(GameRules instance, GameRules.Key<GameRules.BooleanValue> key, @Local(argsOnly = true) ServerPlayer player) {
+        return player.level().getGameRules();
+    }
+
+}

--- a/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
+++ b/arcade-dimensions/src/main/java/net/casual/arcade/dimensions/mixins/level/ServerWaypointManagerMixin.java
@@ -15,13 +15,21 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ServerWaypointManager.class)
 public class ServerWaypointManagerMixin {
-
-    @ModifyReceiver(method = "isLocatorBarEnabledFor", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"))
-    private static GameRules fixVanillaLocatorBarGameRuleCheck(GameRules original, GameRules.Key<GameRules.BooleanValue> key, @Local(argsOnly = true) ServerPlayer player) {
+    @ModifyReceiver(
+        method = "isLocatorBarEnabledFor",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"
+        )
+    )
+    private static GameRules fixVanillaLocatorBarGameRuleCheck(
+        GameRules original,
+        GameRules.Key<GameRules.BooleanValue> key,
+        @Local(argsOnly = true) ServerPlayer player
+    ) {
         if (player.level() instanceof CustomLevel) {
             return player.level().getGameRules();
         }
         return original;
     }
-
 }

--- a/arcade-dimensions/src/main/resources/arcade-dimensions.mixins.json
+++ b/arcade-dimensions/src/main/resources/arcade-dimensions.mixins.json
@@ -12,6 +12,7 @@
     "level.ServerLevelAccessor",
     "level.ServerLevelMixin",
     "level.ServerPlayerMixin",
+    "level.ServerWaypointManagerMixin",
     "level.spawning.LocalMobCapCalculatorMixin",
     "level.spawning.MobCountsMixin",
     "level.spawning.NaturalSpawnerAccessor",


### PR DESCRIPTION
This fixes the issue that would occur when a specific level (usually minigame level) had locator bar disabled, but the level's `ServerWaypointManager` would always resolve to the overworld's gamemode.

This should resolve [CasualChampionships#24](https://github.com/CasualChampionships/CasualChampionships/issues/24)