### PR TITLE
specify exact method info in mixins so other mappings don't cry

### DIFF
--- a/arcade-events-server/src/main/java/net/casual/arcade/events/server/mixins/FlowingFluidMixin.java
+++ b/arcade-events-server/src/main/java/net/casual/arcade/events/server/mixins/FlowingFluidMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(FlowingFluid.class)
 public class FlowingFluidMixin {
 	@ModifyReturnValue(
-		method = "canMaybePassThrough",
+		method = "canMaybePassThrough(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/Direction;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/material/FluidState;)Z",
 		at = @At("RETURN")
 	)
 	private boolean onCanSpreadTo(

--- a/arcade-events-server/src/main/java/net/casual/arcade/events/server/mixins/RegistryDataLoaderMixin.java
+++ b/arcade-events-server/src/main/java/net/casual/arcade/events/server/mixins/RegistryDataLoaderMixin.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(RegistryDataLoader.class)
 public class RegistryDataLoaderMixin {
 	@Inject(
-		method = "loadContentsFromManager",
+		method = "loadContentsFromManager(Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/resources/RegistryOps$RegistryInfoLookup;Lnet/minecraft/core/WritableRegistry;Lcom/mojang/serialization/Decoder;Ljava/util/Map;)V",
 		at = @At("TAIL")
 	)
 	private static <E> void onLoadRegistry(

--- a/arcade-extensions/src/main/java/net/casual/arcade/extensions/mixins/team/ScoreboardMixin.java
+++ b/arcade-extensions/src/main/java/net/casual/arcade/extensions/mixins/team/ScoreboardMixin.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 @Mixin(Scoreboard.class)
 public class ScoreboardMixin {
     @Inject(
-        method = "loadPlayerTeam",
+        method = "loadPlayerTeam(Lnet/minecraft/world/scores/PlayerTeam$Packed;)V",
         at = @At("TAIL")
     )
     private void onLoadPlayerTeam(

--- a/arcade-utils/src/main/java/net/casual/arcade/util/mixins/teams/ScoreboardMixin.java
+++ b/arcade-utils/src/main/java/net/casual/arcade/util/mixins/teams/ScoreboardMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Scoreboard.class)
 public class ScoreboardMixin {
     @Inject(
-        method = "loadPlayerTeam",
+        method = "loadPlayerTeam(Lnet/minecraft/world/scores/PlayerTeam$Packed;)V",
         at = @At("TAIL")
     )
     private void onLoadPlayerTeam(


### PR DESCRIPTION
Some other mappings may or may not use method overloading for their naming, in my specific case, yarn was complaining when I tried to add the dimension  to my project.

Functionally for you guys, these changes do absolutely nothing. It just means my game won't crash anymore when using your lib as yarn wont be trying to figure out "which one did they mean us to inject into?"