### PR TITLE
fix: update maven for mcbrawls inject library  

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ allprojects {
         maven("https://api.modrinth.com/maven")
         maven("https://maven.nucleoid.xyz")
         maven("https://maven.maxhenkel.de/repository/public")
-        maven("https://maven.andante.dev/releases/")
+        maven("https://maven.mcbrawls.net/releases/")
         maven("https://maven4.bai.lol")
         mavenCentral()
     }


### PR DESCRIPTION
(used in arcade-resource-pack-host)

I couldn't connect to the old maven, but this one seems to be working.