### PR TITLE
fix: add null check to player for chat command

### DIFF
--- a/arcade-minigames/src/main/kotlin/net/casual/arcade/minigame/managers/MinigameChatManager.kt
+++ b/arcade-minigames/src/main/kotlin/net/casual/arcade/minigame/managers/MinigameChatManager.kt
@@ -481,7 +481,7 @@ public class MinigameChatManager(
 
     private fun registerCommand() {
         this.minigame.commands.register(CommandTree.buildLiteral("chat") {
-            requires { !minigame.settings.isChatGlobal && minigame.settings.enableChatCommand.get(it.playerOrException) }
+            requires { !minigame.settings.isChatGlobal && it.player?.let { player -> minigame.settings.enableChatCommand.get(player) } ?: false }
             literal("team") {
                 argument("team", TeamArgument.team()) {
                     requiresAdminOrPermission()


### PR DESCRIPTION
Mojang changed `COMMAND_NODE_INSPECTOR` to check requirements as such:
```java
  return !predicate.test(this.noPermissionSource);
```
which leads to it being called without a player context no matter if the console executes it.
This adds a default to the check for the chat command, which previously threw an exception if the command was called by a non-player.