### PR TITLE
Extend team data equality check to include custom arcade data

### DIFF
--- a/arcade-extensions/src/main/java/net/casual/arcade/extensions/mixins/team/PlayerTeamPackedMixin.java
+++ b/arcade-extensions/src/main/java/net/casual/arcade/extensions/mixins/team/PlayerTeamPackedMixin.java
@@ -5,6 +5,8 @@
 package net.casual.arcade.extensions.mixins.team;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mojang.serialization.Codec;
 import net.casual.arcade.extensions.ducks.ArcadeTeamDataHolder;
 import net.casual.arcade.utils.serialization.codec.ArcadeExtraCodecs;
@@ -15,6 +17,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Mixin(PlayerTeam.Packed.class)
@@ -40,6 +43,12 @@ public class PlayerTeamPackedMixin implements ArcadeTeamDataHolder {
                 return packed;
             }
         );
+    }
+
+    @WrapMethod(method = "equals")
+    private boolean extendEquals(Object object, Operation<Boolean> original) {
+        return original.call(object) && object instanceof ArcadeTeamDataHolder holder
+                && Objects.equals(this.arcade$data, holder.arcade$getData());
     }
 
     @Override

--- a/arcade-utils/src/main/java/net/casual/arcade/util/mixins/teams/PlayerTeamPackedMixin.java
+++ b/arcade-utils/src/main/java/net/casual/arcade/util/mixins/teams/PlayerTeamPackedMixin.java
@@ -5,6 +5,8 @@
 package net.casual.arcade.util.mixins.teams;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mojang.serialization.Codec;
 import net.casual.arcade.util.ducks.OverridableColor;
 import net.casual.arcade.utils.serialization.codec.ArcadeExtraCodecs;
@@ -14,6 +16,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Mixin(PlayerTeam.Packed.class)
@@ -50,5 +53,11 @@ public class PlayerTeamPackedMixin implements OverridableColor {
                 return packed;
             }
         );
+    }
+
+    @WrapMethod(method = "equals")
+    private boolean extendEquals(Object object, Operation<Boolean> original) {
+        return original.call(object) && object instanceof OverridableColor color
+                && Objects.equals(this.arcade$color, color.arcade_getColor());
     }
 }


### PR DESCRIPTION
Previously, saving custom team data could be ignored, as changes in it weren't being detected. See: `net.minecraft.world.scores.ScoreboardSaveData#setData`.